### PR TITLE
feat: add hide/show reaction on mouse hover/out for diagrams

### DIFF
--- a/src/controllers/control-panel-controller.ts
+++ b/src/controllers/control-panel-controller.ts
@@ -28,6 +28,10 @@ export default class ControlPanelController {
             foldPanel,
         ]);
 
+        [movePanel, zoomPanel, foldPanel, servicePanel].forEach((panel) => {
+            this.plugin.eventController.addPanelHoverReact(panel);
+        });
+
         container.appendChild(movePanel);
         container.appendChild(zoomPanel);
         container.appendChild(servicePanel);

--- a/src/controllers/event-controller.ts
+++ b/src/controllers/event-controller.ts
@@ -421,4 +421,49 @@ export default class EventController {
             }
         });
     }
+
+    addPanelHoverReact(container: HTMLElement): void {
+        this.plugin.view?.registerDomEvent(
+            container,
+            'mouseover',
+            (e: MouseEvent) => {
+                const target = e.target as HTMLElement | null;
+                if (
+                    target?.matches(
+                        '.hide-when-parent-folded, .diagram-fold-panel'
+                    )
+                ) {
+                    target.setCssStyles({
+                        opacity: '1',
+                    });
+                }
+            }
+        );
+
+        this.plugin.view.registerDomEvent(
+            container,
+            'mouseout',
+            (e: MouseEvent) => {
+                const target = e.target as HTMLElement | null;
+                const relatedTarget = e.relatedTarget as HTMLElement | null;
+                if (!target || !relatedTarget) {
+                    return;
+                }
+
+                const isPanel = target.matches(
+                    '.hide-when-parent-folded, .diagram-fold-panel'
+                );
+                const noParentPanel = !relatedTarget.parentElement?.matches(
+                    '.hide-when-parent-folded, .diagram-fold-panel'
+                );
+                if (isPanel && noParentPanel) {
+                    target.setCssStyles({
+                        opacity: (
+                            this.plugin.settings.panelsOpacityOnHide * 0.1
+                        ).toString(),
+                    });
+                }
+            }
+        );
+    }
 }

--- a/src/controllers/event-controller.ts
+++ b/src/controllers/event-controller.ts
@@ -422,10 +422,10 @@ export default class EventController {
         });
     }
 
-    addPanelHoverReact(container: HTMLElement): void {
+    addPanelHoverReact(panel: HTMLElement): void {
         this.plugin.view?.registerDomEvent(
-            container,
-            'mouseover',
+            panel,
+            'mouseenter',
             (e: MouseEvent) => {
                 const target = e.target as HTMLElement | null;
                 if (
@@ -441,22 +441,20 @@ export default class EventController {
         );
 
         this.plugin.view.registerDomEvent(
-            container,
-            'mouseout',
+            panel,
+            'mouseleave',
             (e: MouseEvent) => {
                 const target = e.target as HTMLElement | null;
-                const relatedTarget = e.relatedTarget as HTMLElement | null;
-                if (!target || !relatedTarget) {
+
+                if (!target) {
                     return;
                 }
 
-                const isPanel = target.matches(
+                const wasIsPanel = target.matches(
                     '.hide-when-parent-folded, .diagram-fold-panel'
                 );
-                const noParentPanel = !relatedTarget.parentElement?.matches(
-                    '.hide-when-parent-folded, .diagram-fold-panel'
-                );
-                if (isPanel && noParentPanel) {
+
+                if (wasIsPanel) {
                     target.setCssStyles({
                         opacity: (
                             this.plugin.settings.panelsOpacityOnHide * 0.1

--- a/src/core/diagram-zoom-drag-plugin.ts
+++ b/src/core/diagram-zoom-drag-plugin.ts
@@ -228,6 +228,7 @@ export default class DiagramZoomDragPlugin extends Plugin {
                 this.eventController.addMouseEvents(container);
                 this.mutationObserverController.addFoldingObserver(container);
                 this.eventController.addFocusEvents(container);
+                this.eventController.addPanelHoverReact(container);
 
                 if (this.settings.foldByDefault) {
                     container.addClass('folded');

--- a/src/core/diagram-zoom-drag-plugin.ts
+++ b/src/core/diagram-zoom-drag-plugin.ts
@@ -228,7 +228,6 @@ export default class DiagramZoomDragPlugin extends Plugin {
                 this.eventController.addMouseEvents(container);
                 this.mutationObserverController.addFoldingObserver(container);
                 this.eventController.addFocusEvents(container);
-                this.eventController.addPanelHoverReact(container);
 
                 if (this.settings.foldByDefault) {
                     container.addClass('folded');

--- a/src/settings/settings-manager.ts
+++ b/src/settings/settings-manager.ts
@@ -12,6 +12,7 @@ export interface DEFAULT_SETTINGS_Interface {
     supported_diagrams: DiagramData[];
     foldByDefault: boolean;
     automaticFolding: boolean;
+    panelsOpacityOnHide: number;
 }
 
 export default class SettingsManager {
@@ -35,6 +36,7 @@ export default class SettingsManager {
             ),
             foldByDefault: false,
             automaticFolding: false,
+            panelsOpacityOnHide: 1,
         };
     }
 

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -49,6 +49,20 @@ export class SettingsTab extends PluginSettingTab {
                     });
             });
 
+        new Setting(containerEl)
+            .setName('Diagram opacity on hide')
+            .addSlider((slider) => {
+                slider
+                    .setValue(this.plugin.settings.panelsOpacityOnHide)
+                    .onChange(async (value) => {
+                        slider.setValue(value);
+                        this.plugin.settings.panelsOpacityOnHide = value;
+                        await this.plugin.settingsManager.saveSettings();
+                    })
+                    .setLimits(0, 10, 1)
+                    .setDynamicTooltip();
+            });
+
         new Setting(containerEl).setHeading().setName('Diagram management');
 
         const addDiagram = new Setting(containerEl);

--- a/styles.css
+++ b/styles.css
@@ -170,3 +170,7 @@
 .diagram-container.folded {
     height: 20vh;
 }
+
+.hide-when-parent-folded {
+    transition: opacity 0.3s ease;
+}


### PR DESCRIPTION
- Implement hover reactions for diagrams: diagrams will show on mouse over and hide on mouse out.
- Introduce new options in the plugin settings:
  - Option to set the opacity for hidden diagrams.